### PR TITLE
Add a sleep during every scan round to avoid dead loop.

### DIFF
--- a/dora/core/common/src/main/java/alluxio/collections/LockPool.java
+++ b/dora/core/common/src/main/java/alluxio/collections/LockPool.java
@@ -158,6 +158,7 @@ public class LockPool<K> implements Closeable {
           if (!mIterator.hasNext()) {
             mIterator = mPool.entrySet().iterator();
             roundToScan--;
+            mOverHighWatermark.await(EVICTION_MAX_AWAIT_TIME, TimeUnit.MILLISECONDS);
           }
           Map.Entry<K, Resource> candidateMapEntry = mIterator.next();
           Resource candidate = candidateMapEntry.getValue();


### PR DESCRIPTION
### What changes are proposed in this pull request?
For big data tasks (eg, spark), might write a lot of files in the final stage. In that case, there will be a lot of write edge locks, which would trigger lockpool evict. All the locks have refcounts greater than 0, which means the locks cannot be evicted during that scan, and the lock pool size will keep what it is. There is no pause during each scan, and a dead loop accour. The server load grows up, and Alluxio master cannot offer service. So we add a wait during each scan to avoid this.

![image](https://github.com/xihuanbanku/alluxio/assets/11374717/d2a33504-9baf-4219-83c4-680e8638402e)
The following pic shows server load grows very high.
![image](https://github.com/xihuanbanku/alluxio/assets/11374717/8f2229b3-8016-4399-84a8-c6967dfcaf80)
The jstack for Alluxio Master. (The nid matches java thread id.)
![image](https://github.com/xihuanbanku/alluxio/assets/11374717/f3e15d67-8644-4de3-8c59-9803c6535229)
